### PR TITLE
Fixes edit links, removes placeholders from main page

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,16 +1,4 @@
   <hr>
-  <div class="container" id="footer">
-    <div class="row-fluid">
-      <div class="span12">
-        <div class="pull-left">
-            <!-- <div class="btn btn-primary" href="{{ edit_url }}">Edit this Page</a>
-        </div>
-<div class="pull-right">
-          <iframe src={{ site.url }}/assets/ghbtns/github-btn.html?user={{ site.org_name }}&repo={{ site.repo_name }}&type=fork&count=true" allowtransparency="true" frameborder="0" scrolling="0" width="95" height="20"></iframe>
-        </div>
-      </div>
-    </div>
-  </div><!-- /container -->
 
 
   <script src="{{ site.url }}/assets/js/vendor/jquery-1.11.1.min.js"></script>

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -27,8 +27,6 @@
       window.location.protocol = "https";
   </script>
 
-  <!--{% capture edit_url %}https://github.com/{{ site.org_name }}/{{ site.repo_name }}/edit/{{ site.branch }}/{{ page.path }}{% endcapture %}<![endif]-->
-
 </head>
 <body class="{{ page.id }}">
   <!--[if lt IE 7]>
@@ -56,7 +54,8 @@
       </div>
       <div class="navbar-collapse collapse">
         <ul class="nav navbar-nav navbar-right">
-          <!-- <li><a class="edit-button" href="https://github.com/WhiteHouse/cyber-acquisitions/blob/gh-pages/index.md"><span>Edit Guidance</span></a></li>
+          <li><a class="edit-button" href="https://github.com/{{ site.org_name }}/{{ site.repo_name }}/edit/{{ site.branch }}/{{ page.path }}"><span>Edit Guidance</span></a></li>
+
 	  <li><a class="edit-button" href="https://github.com/WhiteHouse/cyber-acquisitions/issues"><span>Provide Feedback</span></a></li>
           <!-- li class="dropdown">
            <a href="#" class="dropdown-toggle" data-toggle="dropdown">Sections<span class="caret"></span></a>

--- a/index.md
+++ b/index.md
@@ -6,9 +6,7 @@ filename: index.md
 title: Cyber Contracting Guidance
 ---
 
-## Improving Cybersecurity Protections in Federal Acquisitions 
-
-### [Edit Guidance](https://github.com/WhiteHouse/cyber-acquisitions/edit/gh-pages/index.md "Link to the Pull Requests Section of GitHub") | [Discuss Guidance](https://github.com/WhiteHouse/cyber-acquisitions/issues "Link to the Issues Section of GitHub")
+## Improving Cybersecurity Protections in Federal Acquisitions
 
 ### Introduction
 In early 2015 the Federal Chief Information Officers (CIO) Council and the Chief Acquisition Officers (CAO) Council created a working group to review current contract clauses and information technology (IT) acquisition policies and practices around contractor and subcontractor information system security. This interagency group was comprised of senior experts in acquisition, security, and contract management and their recommendations are included in this guidance to Federal agencies on implementing strengthened cybersecurity protections in Federal acquisitions.
@@ -28,7 +26,7 @@ The public feedback period will be 30 days, and comments will be reviewed using 
 You may provide feedback in two ways:
 
 1.	Content suggestions and discussions are welcome via GitHub “issues.” Each issue is a conversation initiated by a member of the public. We encourage you to browse and [join in on discussions](https://github.com/WhiteHouse/cyber-acquisitions/issues "Link to the Issues Section of GitHub") in existing issues, or start a new conversation by opening a [new issue](https://github.com/WhiteHouse/cyber-acquisitions/issues/new).
-2.	Direct changes and line edits to the content may be submitted through a ["pull request"](https://help.github.com/articles/creating-a-pull-request "More Information on Submitting Pull Requests") by clicking ["Edit Guidance."](https://github.com/WhiteHouse/cyber-acquisitions/edit/gh-pages/index.md "Link to the Pull Requests Section of GitHub") You dont need to install any software to suggest a change. You can use GitHub's in-browser editor to edit files and submit a pull request for your changes to be merged into the document. Directions on how to submit a pull request can be found [here](https://help.github.com/articles/creating-a-pull-request "More Information on Submitting Pull Requests"). Open pull request for the proposed guidance can be found [here](https://github.com/WhiteHouse/cyber-acquisitions/pulls). 
+2.	Direct changes and line edits to the content may be submitted through a ["pull request"](https://help.github.com/articles/creating-a-pull-request "More Information on Submitting Pull Requests") by clicking ["Edit Guidance."](https://github.com/WhiteHouse/cyber-acquisitions/edit/gh-pages/index.md "Link to the Pull Requests Section of GitHub") You dont need to install any software to suggest a change. You can use GitHub's in-browser editor to edit files and submit a pull request for your changes to be merged into the document. Directions on how to submit a pull request can be found [here](https://help.github.com/articles/creating-a-pull-request "More Information on Submitting Pull Requests"). Open pull request for the proposed guidance can be found [here](https://github.com/WhiteHouse/cyber-acquisitions/pulls).
 
 _[Return to the Top]()_
 
@@ -39,15 +37,15 @@ While the Federal Government has taken significant across to enhance Federal ass
 2. **How will the guidance strengthen information security within the government?**
 The proposed guidance will strengthen government agencies’ clauses regarding the type of security controls that apply, notification requirements for when an incident occurs, and the requirements around assessments and monitoring of systems.  In addition to this, the Guidance outlines a business due diligence service that agencies can use to help ensure they are contracting for secure products and services.
 
-3. **What is the foundation for this guidance?**  
+3. **What is the foundation for this guidance?**
 The requirements within the proposed guidance originate from the following:
- * The Federal Information Security Modernization Act of 2014 (FISMA), Office of Management and Budget (OMB) policy, and National Institute of Standards and Technology (NIST) standards provide agencies with a framework for securing government and contractor information systems. 
+ * The Federal Information Security Modernization Act of 2014 (FISMA), Office of Management and Budget (OMB) policy, and National Institute of Standards and Technology (NIST) standards provide agencies with a framework for securing government and contractor information systems.
  * NIST Special Publication (SP) 800-37, the Guide for Applying the Risk Management Framework to Federal Information Systems, provides requirements for annually reporting of the overall effectiveness of the organization’s information security program, including progress of remedial actions noted during security assessments. This document suggests using the moderate security control baseline in NIST SP 800-53.
  * SP 800-53, Security and Privacy Controls for Federal Information Systems and Organizations, details the steps of the Risk Management Framework (RMF) that addresses security controls used to assess Federal information systems as part of the Security Assessment & Authorization (SA&A) process. These security controls are used to evaluate logical and physical access to systems, and include examination in the areas of access control, auditing, incident response, media protection, business continuity, and disaster recovery. The latest revision of this document includes newly added privacy controls. All Federal information systems must be “SP 800-53 compliant” in order to be granted an Authority to Operate (ATO).
  * NIST SP 800-171, Protecting Controlled Unclassified Information in Nonfederal Information Systems and Organizations, provides Federal agencies with recommended requirements for protecting the confidentiality of CUI in non-federal systems and organizations where the data is processed, stored, or transmitted.
  * Executive Order 13556 – Controlled Unclassified Information (CUI). This order established a program for managing information that requires safeguarding or dissemination controls pursuant to and consistent with law, regulations, and Government-wide policies.
 
-4. **How will compliance with this guidance be measured?**  
+4. **How will compliance with this guidance be measured?**
 OMB will review compliance during FedStat and CyberStat sessions, including:
 
  * Agency continual review of contract activities to ensure that the guidance in this proposed memorandum is applied.
@@ -60,17 +58,17 @@ Agencies currently have the legal authority to consider performance problems of 
 6. **Are there restrictions on "foreign" participation in these Federal information technology contracts?**
 Federal law restricts “foreign” participation in Federal procurement in several ways, but acquisitions of services are not subject to the Buy American Act (BAA) of 1933 or similar domestic content restrictions. In addition, 10 U.S.C. § 2327 prohibits contracts with companies in which foreign governments that support international terrorism have a “significant interest.”
 
-7. **How will non-federal information systems and organizations be assessed?**  
- * This assessment will depend on whether the system is being operated on behalf of the government or if the system is an internal contractor system that contains CUI. 
- * If possible, agencies should use relevant existing ATOs as an indication of common controls and capabilities for the performance of multiple contracts. 
- * Agencies should first use Federal Information Processing Standard (FIPS)-199 to assess the impact level of the data that is to reside in the contractor’s information system in order to determine what types of controls should be applied, followed by determining whether it is appropriate to obtain an independent security assessment. 
+7. **How will non-federal information systems and organizations be assessed?**
+ * This assessment will depend on whether the system is being operated on behalf of the government or if the system is an internal contractor system that contains CUI.
+ * If possible, agencies should use relevant existing ATOs as an indication of common controls and capabilities for the performance of multiple contracts.
+ * Agencies should first use Federal Information Processing Standard (FIPS)-199 to assess the impact level of the data that is to reside in the contractor’s information system in order to determine what types of controls should be applied, followed by determining whether it is appropriate to obtain an independent security assessment.
  * Agencies may accept independent third party verification of security assessment results, contractor, or government assessment evidence based on its risk assessment.
  * The assessment of privacy controls must be performed by the Senior Agency Official for Privacy (SAOP).
  * After performance under the contract has begun, agencies shall conduct security reviews on a periodic and event-driven basis for the life of the contract.
  * The agency may elect to perform information security continuous monitoring and IT security scanning of contractor systems.
 
 8. **How can people submit feedback and when is the deadline?**
-Feedback can be submitted by visiting policy.cio.gov and following the posted instructions. We are accepting comments for 30 days. 
+Feedback can be submitted by visiting policy.cio.gov and following the posted instructions. We are accepting comments for 30 days.
 
 9. **When will the final policy be released?**
 Following the public feedback period, OMB will analyze all submitted feedback and revise the policy as necessary. The final guidance will be released Fall 2015.
@@ -87,11 +85,11 @@ The threats facing Federal information systems have dramatically increased as ag
 
 In early 2015, OMB tasked the Federal Chief Information Officer (CIO) Council and the Chief Acquisition Officer (CAO) Council (“the Councils”) to review current acquisition and IT policies and practices around contractor and subcontractor information system security.  This review would inform recommendations for improvement, consistent with the 2014 Federal Information Security Modernization Act (FISMA),[^4] to ensure contractors provide adequate security for Federal information.  To help perform this review, agencies shared with OMB contract language, policies, and related documents addressing cybersecurity.  An interagency group comprised of senior experts in acquisition, security, and contract management recommended that existing agency contract language and other relevant information be available to other agencies and for OMB to issue guidance in the following areas to strengthen the protection of CUI held by Federal contractors:
 
-* Incident Reporting and Notification; 
-* Information System Assessments; and 
+* Incident Reporting and Notification;
+* Information System Assessments; and
 * Information Security Continuous Monitoring
 
-In response to these recommendations, OMB has established a repository of agency information, including sample contract clauses on MAX.gov,[^5] that agencies are encouraged to review to gain insight into existing peer practices.  OMB has developed this management memorandum to build on individual agency efforts, clarify applications of security controls, and provide government-wide guidance on the key issues identified by the working group for strengthening cybersecurity protections in their acquisitions. 
+In response to these recommendations, OMB has established a repository of agency information, including sample contract clauses on MAX.gov,[^5] that agencies are encouraged to review to gain insight into existing peer practices.  OMB has developed this management memorandum to build on individual agency efforts, clarify applications of security controls, and provide government-wide guidance on the key issues identified by the working group for strengthening cybersecurity protections in their acquisitions.
 
 This memorandum also describes steps that agencies should take to perform better business due diligence to support risk management throughout the entire lifespan of an outsourced capability.  This includes incorporating robust business due diligence into the full acquisition, sustainment, and disposal lifecycles, starting with requirements definition, acquisition planning, and market research, through solicitation, source selection, and contract administration, and ending with retirement and disposal.  Performing increased business due diligence will help ensure the Government bases its decisions on the best available information about the risks involved in the program.  Research to support business due diligence should encompass public record, publically available, and commercial subscription data to provide comprehensive information about current and prospective contractors and subcontractors to highlight potential security and other risks in the outsourced mission capability. General Services Administration (GSA) shall develop a business due diligence information shared service that gives agencies a holistic view of organizations doing business with the Government.  GSA will support efforts to standardize vendor common risk indicators, to include cybersecurity risk indicators, in support of agency enterprise risk management and complement existing agency-specific programs.
 
@@ -106,21 +104,21 @@ The guidance distinguishes between systems operated ‘on behalf of the Governme
 The approach to protecting information and the responsibilities imposed on contractors is different in each of these situations.  As explained below, systems operated on behalf of the Government are generally required to meet NIST SP 800-53 and conform to the same processes as do government systems.  Systems operated for multiple users will likely require variations from the standard government processes or terms of service.  Internal information systems are generally subject to the requirements described in NIST SP 800-171.[^6]
 
 ### Guidance
-The agency’s CIO, CAO, Chief Information Security Officer, senior agency official for privacy, and other key stakeholders shall immediately begin working together to apply the guidance below.  Agencies should continuously review contract activities to ensure this guidance is being applied.  Additionally, OMB will review compliance during FedStat and CyberStat sessions. 
-To support these efforts and to move towards greater uniformity, the Federal Acquisition Regulatory Council will amend the Federal Acquisition Regulation (FAR) to provide for inclusion of contract clauses that address, as appropriate, the guidance covered in sections 1-4 below in Federal procurement solicitations and contracts. 
+The agency’s CIO, CAO, Chief Information Security Officer, senior agency official for privacy, and other key stakeholders shall immediately begin working together to apply the guidance below.  Agencies should continuously review contract activities to ensure this guidance is being applied.  Additionally, OMB will review compliance during FedStat and CyberStat sessions.
+To support these efforts and to move towards greater uniformity, the Federal Acquisition Regulatory Council will amend the Federal Acquisition Regulation (FAR) to provide for inclusion of contract clauses that address, as appropriate, the guidance covered in sections 1-4 below in Federal procurement solicitations and contracts.
 
 #### 1.  Security Controls
-For systems operated on behalf of the Government, the agency must require the contractor system to meet the appropriate baseline in NIST SP 800-53 as modified by the agency to meet its risk management requirements.  Use of NIST SP 800-53 will provide a consistent approach across agencies.  For CUI, the moderate baseline for confidentiality should be applied and adjusted for any specific protection requirements required by law, regulation, or government wide policy.  When the contractor is operating the system to process data from more than one agency, or when there are non-government customers (e.g., cloud service providers), the agency should review the risk management and tailoring processes in NIST SP 800-37 and SP 800-53, which provide mechanisms to accommodate these situations. 
+For systems operated on behalf of the Government, the agency must require the contractor system to meet the appropriate baseline in NIST SP 800-53 as modified by the agency to meet its risk management requirements.  Use of NIST SP 800-53 will provide a consistent approach across agencies.  For CUI, the moderate baseline for confidentiality should be applied and adjusted for any specific protection requirements required by law, regulation, or government wide policy.  When the contractor is operating the system to process data from more than one agency, or when there are non-government customers (e.g., cloud service providers), the agency should review the risk management and tailoring processes in NIST SP 800-37 and SP 800-53, which provide mechanisms to accommodate these situations.
 
 For contractors’ internal systems used to provide a product or service for the Government but incidentally contain CUI, the application of NIST SP 800-53 controls is generally not appropriate.  NIST recently published NIST SP 800-171, Protecting Controlled Unclassified Information in Nonfederal Information Systems and Organizations.  Agencies should require contractors whose internal information systems will process CUI incidental to developing a product or service for the agency to meet the requirements of NIST SP 800-171 rather than NIST SP 800-53.
 
 #### 2.  Cyber Incident Reporting
-For purposes of this guidance, “cyber incident” means actions taken through the use of computer networks that result in a compromise or an actual or potentially adverse effect on an information system and/or the information residing therein.  Cyber incident reporting requirements for systems operated on behalf of the government and contractors’ internal systems are similar.  The only distinction is that the reporting of cyber incidents affecting a contractor’s internal system is limited to incidents affecting CUI, not every cyber incident affecting the contractor system. 
+For purposes of this guidance, “cyber incident” means actions taken through the use of computer networks that result in a compromise or an actual or potentially adverse effect on an information system and/or the information residing therein.  Cyber incident reporting requirements for systems operated on behalf of the government and contractors’ internal systems are similar.  The only distinction is that the reporting of cyber incidents affecting a contractor’s internal system is limited to incidents affecting CUI, not every cyber incident affecting the contractor system.
 
 Timely contractor reporting of all cyber incidents involving the loss of confidentiality, integrity, or availability of data is critical to the Government’s ability to determine appropriate response actions and minimize harm from incidents.  During the Councils’ consultation with agencies, it was determined that agency contracts often lack language governing when and how contractors are required to report information security incidents when they occur and when and how contractors should provide notification of breaches to affected individuals and third parties.  At a minimum, agency contractual language regarding incident reporting shall include the following:
 
- * Language to indicate that a cyber incident that is properly reported by the contractor shall not, but itself, be interpreted as evidence that the contractor has failed to provide adequate information safeguards for CUI; 
- * The definition of what constitutes a cyber incident; 
+ * Language to indicate that a cyber incident that is properly reported by the contractor shall not, but itself, be interpreted as evidence that the contractor has failed to provide adequate information safeguards for CUI;
+ * The definition of what constitutes a cyber incident;
  * The required timeline for first reporting to the agency;
  * The types of information required in a cyber incident report to include: company and point of contact information, contract information, the type of information compromised;
  * The contractor shall send only one report to each agency POC identified in the contracts, not a report for each contract from that agency. The report may contain information required by other agencies, so one report may satisfy the requirements of multiple agencies; and
@@ -128,13 +126,13 @@ Timely contractor reporting of all cyber incidents involving the loss of confide
 
 The specific requirements included in the contractual language shall be based on Federal law, OMB policies, NIST standards and guidelines, and other applicable standards and policies. This approach to reporting will promote timely and meaningful information sharing that allows both the contractor and the agency to work closely together to investigate the incident, identify affected individuals, quickly respond to the incident and take other appropriate actions as necessary.
 
-In determining the appropriate timeline and reporting information, agencies shall comply with Federal law, relevant OMB policies, and NIST standards and guidelines.  Agencies must also consider the sensitivity of the information stored by the contractor, the potential damage caused by delays in reporting, the requirements in the Department of Homeland Security (DHS) United States Computer Emergency Readiness Team (US-CERT) Federal Incident Notification Guidelines,[^7] or other risk factors, as deemed appropriate by an agency. 
+In determining the appropriate timeline and reporting information, agencies shall comply with Federal law, relevant OMB policies, and NIST standards and guidelines.  Agencies must also consider the sensitivity of the information stored by the contractor, the potential damage caused by delays in reporting, the requirements in the Department of Homeland Security (DHS) United States Computer Emergency Readiness Team (US-CERT) Federal Incident Notification Guidelines,[^7] or other risk factors, as deemed appropriate by an agency.
 
 At a minimum, contractual language shall ensure that all known or suspected cyber incidents involving the loss of confidentiality, integrity or availability of data for systems operated on behalf of the Government are reported to the designated agency Computer Security Incident Response Team (CSIRT) or Security Operations Center (SOC) within the timeline agreed upon in the contract. All known cyber incidents in contractor internal systems must be reported if they involve the CUI in the system, but the contractor does not have to report all known or suspected cyber incidents.  In addition to reporting to the SOC, the contractor shall also report the security incident to the:
 
- * Contracting Officer (CO); 
- * Contracting Officer Representative (COR); 
- * Chief Information Security Officer (CISO); and  
+ * Contracting Officer (CO);
+ * Contracting Officer Representative (COR);
+ * Chief Information Security Officer (CISO); and
  * Senior agency official for privacy (SAOP).
 
 #### 3.  Information System Security Assessments
@@ -144,48 +142,48 @@ Agencies should consider the following when developing the requirements for asse
 
  * Agencies should first use Federal Information Processing Standard (FIPS)-199[^10] to assess the impact level of the data that is to reside in the contractor’s information system in order to determine what types of controls should be applied, followed by determining whether it is appropriate to obtain an independent security assessment;
  * Agencies may accept independent third-party verification of security assessment results, contractor, or government assessment evidence based on its risk assessment;
- * The assessment of privacy controls must be performed by the SAOP; and 
+ * The assessment of privacy controls must be performed by the SAOP; and
  * After performance under the contract has begun, agencies shall ensure agencies are granted access for security reviews on a periodic and event-driven basis for the life of the contract.
 
 Security assessments not only confirm that contractors are maintaining their security posture; they also allow the agency to validate the maintenance of the previously performed independent assessment.
 
-The agency should specify that the contractor will afford the agency access to the contractor’s facilities, installations, operations, documentation, databases, IT systems, devices, and personnel used in performance of the contract, regardless of location.  Access shall be provided to the extent required to conduct an inspection, evaluation, investigation or audit and to preserve evidence of information security incidents. Finally, agencies should include contract language requiring that, prior to contract closeout, the contractor must:  
+The agency should specify that the contractor will afford the agency access to the contractor’s facilities, installations, operations, documentation, databases, IT systems, devices, and personnel used in performance of the contract, regardless of location.  Access shall be provided to the extent required to conduct an inspection, evaluation, investigation or audit and to preserve evidence of information security incidents. Finally, agencies should include contract language requiring that, prior to contract closeout, the contractor must:
 
- * Certify and confirm the sanitization of government and government-activity-related files and information; and 
- * Submit the certification to the Contracting Contracting Officer following the template provided in NIST SP 800-88 Guidelines for Media Sanitization.[^11] 
+ * Certify and confirm the sanitization of government and government-activity-related files and information; and
+ * Submit the certification to the Contracting Contracting Officer following the template provided in NIST SP 800-88 Guidelines for Media Sanitization.[^11]
 
 The agency should then review the contractor’s sanitization certification to make sure any risk has been mitigated.  To the extent that a contractor generated, maintained, transmitted, stored, or processed PII, the SAOP should review the certification.
 
-Agencies should identify in the contract solicitation how they expect the contractor to demonstrate in its proposal that it meets the requirements of NIST SP 800-171, including the security assessment for contractor internal systems. This can range, depending upon the impact level of the information at risk, from simple attestation of compliance to detailed description of the system’s security architecture, controls, and provision of supporting test data. 
+Agencies should identify in the contract solicitation how they expect the contractor to demonstrate in its proposal that it meets the requirements of NIST SP 800-171, including the security assessment for contractor internal systems. This can range, depending upon the impact level of the information at risk, from simple attestation of compliance to detailed description of the system’s security architecture, controls, and provision of supporting test data.
 
 #### 4.  Information Security Continuous Monitoring
-Due to the increase and complexity of information security incidents, and the need to react quickly, the Federal Government has prioritized Information Security Continuous Monitoring (ISCM), an initiative identified in NIST SP 800-53 and OMB Memorandum M-14-03.[^12]  ISCM is defined in NIST SP 800-137[^13]  “as maintaining ongoing awareness of information security, vulnerabilities, and threats to support organizational risk management decisions” but is not limited to a specific program or technology. To assist agencies in establishing ISCM capabilities quickly, the DHS has created the Continuous Diagnostics and Mitigation (CDM) program and much of the information reported under ISCM is required under existing OMB guidance.  If the agency determines that providing the DHS CDM capabilities to a contractor operating information systems on behalf of the Government is not feasible, the contract must ensure that at a minimum:  
+Due to the increase and complexity of information security incidents, and the need to react quickly, the Federal Government has prioritized Information Security Continuous Monitoring (ISCM), an initiative identified in NIST SP 800-53 and OMB Memorandum M-14-03.[^12]  ISCM is defined in NIST SP 800-137[^13]  “as maintaining ongoing awareness of information security, vulnerabilities, and threats to support organizational risk management decisions” but is not limited to a specific program or technology. To assist agencies in establishing ISCM capabilities quickly, the DHS has created the Continuous Diagnostics and Mitigation (CDM) program and much of the information reported under ISCM is required under existing OMB guidance.  If the agency determines that providing the DHS CDM capabilities to a contractor operating information systems on behalf of the Government is not feasible, the contract must ensure that at a minimum:
 
  * Contractor-operated systems meet or exceed the information security continuous monitoring requirements identified in M-14-03; and
- * The agency may elect to perform information security continuous monitoring and IT security scanning of contractor systems with tools and infrastructure of its choosing. 
+ * The agency may elect to perform information security continuous monitoring and IT security scanning of contractor systems with tools and infrastructure of its choosing.
 
-While existing contracts may direct the contractor to self-report required ISCM information to the agency, this approach may no longer be sufficient.  Agencies and contractors must therefore work together to determine and implement an appropriate solution that fulfills the ISCM requirements. Agencies should work with DHS to ensure that the proposed solution fulfills the ISCM requirements identified in FISMA. 
+While existing contracts may direct the contractor to self-report required ISCM information to the agency, this approach may no longer be sufficient.  Agencies and contractors must therefore work together to determine and implement an appropriate solution that fulfills the ISCM requirements. Agencies should work with DHS to ensure that the proposed solution fulfills the ISCM requirements identified in FISMA.
 
-For systems not operated on behalf of the Government – contractor’s internal systems used to develop a product or service – continuous monitoring is part of the security assessment requirement in NIST SP 800-171. 
- 
+For systems not operated on behalf of the Government – contractor’s internal systems used to develop a product or service – continuous monitoring is part of the security assessment requirement in NIST SP 800-171.
+
 #### 5.  Business Due Diligence
 Cybersecurity protections in Federal acquisitions can be further enhanced by performing increased business due diligence to gain better visibility into, and understanding of, how contractors develop, integrate, and deploy their products, services, and solutions as well as how they assure integrity, security, resilience, and quality in their operations. GSA has been working with agencies to explore and pilot the use of public records, publicly available, and commercial subscription data to support business due diligence analyses. Such analyses are consistent with the guidelines in NIST SP 800-161, Supply Chain Risk Management Practices for Federal Information Systems and Organizations, which calls for agencies to frame, assess, respond to, and monitor information and information system-related security and supply chain risks using a holistic, organization-wide risk management process.
 
-Accordingly:  
+Accordingly:
 
- * Agency program offices shall work with their CIOs to identify and prioritize planned acquisitions and contracts that can benefit from business due diligence research; 
+ * Agency program offices shall work with their CIOs to identify and prioritize planned acquisitions and contracts that can benefit from business due diligence research;
  * Building on the work it has done to date, GSA shall create a business due diligence information shared service.  This shared service will provide agencies with access to risk information that encompasses data collected from voluntary contractor reporting, public records, publically available and commercial subscription data based on transparent, objective, and measurable risk indicators;
- * GSA shall make research tools available for these purposes for use by agencies throughout the acquisition, sustainment, and disposal lifecycles.  These efforts shall be complementary to, and not a replacement for, existing government supply chain risk management activities that agencies conduct; and 
+ * GSA shall make research tools available for these purposes for use by agencies throughout the acquisition, sustainment, and disposal lifecycles.  These efforts shall be complementary to, and not a replacement for, existing government supply chain risk management activities that agencies conduct; and
  * Within 90 days of the issuance of this memorandum, the interagency cybersecurity group established by the CIO and CAO Councils shall work with GSA to identify and make recommendations to the Federal CIO and the Administrator for Federal Procurement Policy on risk indicators that should be used as a baseline for business due diligence research and other core requirements for the shared service.
 
 _[Return to the Top]()_
 
 ## Endnotes
 
-[^1]:  NIST SP 800-171: Controlled Unclassified Information is any information that law, regulation, or Government-wide policy requires to have safeguarding or disseminating controls, excluding information that is classified under Executive Order 13526, Classified National Security Information, December 29, 2009, or any predecessor or successor order, or the Atomic Energy Act of 1954, as amended. 
+[^1]:  NIST SP 800-171: Controlled Unclassified Information is any information that law, regulation, or Government-wide policy requires to have safeguarding or disseminating controls, excluding information that is classified under Executive Order 13526, Classified National Security Information, December 29, 2009, or any predecessor or successor order, or the Atomic Energy Act of 1954, as amended.
 [^2]:  [http://www.gpo.gov/fdsys/pkg/FR-2010-11-09/pdf/2010-28360.pdf] (http://www.gpo.gov/fdsys/pkg/FR-2010-11-09/pdf/2010-28360.pdf)
 [^3]:  [https://www.congress.gov/bill/113th-congress/senate-bill/2521/text] (https://www.congress.gov/bill/113th-congress/senate-bill/2521/text)
-[^4]:  See 44 U.S.C. 3553 “information collected or maintained by or on behalf of an agency or information systems used or operated by an agency or by a contractor of an agency or other organization on behalf of an agency. 
+[^4]:  See 44 U.S.C. 3553 “information collected or maintained by or on behalf of an agency or information systems used or operated by an agency or by a contractor of an agency or other organization on behalf of an agency.
 [^5]:  [https://community.max.gov/x/xwIiLg] ([https://community.max.gov/x/xwIiLg)
 [^6]:  [http://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-171.pdf] (http://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-171.pdf)
 [^7]:  [https://www.us-cert.gov/incident-notification-guidelines] (https://www.us-cert.gov/incident-notification-guidelines)
@@ -193,7 +191,7 @@ _[Return to the Top]()_
 [^9]:  ibid. (http://csrc.nist.gov/publications/nistpubs/800-37-rev1/sp800-37-rev1-final.pdf)
 [^10]: [http://csrc.nist.gov/publications/fips/fips199/FIPS-PUB-199-final.pdf] (http://csrc.nist.gov/publications/fips/fips199/FIPS-PUB-199-final.pdf)
 [^11]: [http://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-88r1.pdf] (http://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-88r1.pdf)
-[^12]: [https://www.whitehouse.gov/sites/default/files/omb/memoranda/2014/m-14-03.pdf] (https://www.whitehouse.gov/sites/default/files/omb/memoranda/2014/m-14-03.pdf) 
+[^12]: [https://www.whitehouse.gov/sites/default/files/omb/memoranda/2014/m-14-03.pdf] (https://www.whitehouse.gov/sites/default/files/omb/memoranda/2014/m-14-03.pdf)
 [^13]: [http://csrc.nist.gov/publications/nistpubs/800-137/SP800-137-Final.pdf] (http://csrc.nist.gov/publications/nistpubs/800-137/SP800-137-Final.pdf)
 
 _[Return to the Top]()_


### PR DESCRIPTION
This restores the edit/discuss buttons to the top of the page, and removes the two links from the homepage that I believe were put there as a stopgap.

The top of the page now looks like this:

![screenshot from 2015-08-12 02-54-04](https://cloud.githubusercontent.com/assets/4592/9218114/776c5be2-409d-11e5-8dbd-bd1f3d2e1b28.png)

The edit button's URL is constructed using the github org/repo/branch data specified in `_config.yml`, and should work automatically for any pages you add to this project beyond just `index.md`.
